### PR TITLE
 Multiple proof request bug

### DIFF
--- a/lib/iden3comm/domain/use_cases/get_iden3comm_proofs_use_case.dart
+++ b/lib/iden3comm/domain/use_cases/get_iden3comm_proofs_use_case.dart
@@ -80,8 +80,11 @@ class GetIden3commProofsUseCase
                     genesisDid: param.genesisDid,
                     profileNonce: param.profileNonce,
                     privateKey: param.privateKey))
-            .then((claim) => claim.first)
-            .then((credential) async {
+            .then((claims) {
+          ClaimEntity claimForRequest = claims.firstWhere(
+              (element) => element.type == request.scope.query.type);
+          return claimForRequest;
+        }).then((credential) async {
           String circuitId = request.scope.circuitId;
           CircuitDataEntity circuitData =
               await _proofRepository.loadCircuitFiles(circuitId);


### PR DESCRIPTION
fixing bug that in case of the same schema took the first credential even if it is of the wrong type (example KYCAgeCredential and KYCCountryOfResidenceCredential are part of the same schema)