### PR TITLE
chore: Automatically close state issues after 30 days of inactivity

### DIFF
--- a/.github/workflows/autoclose_stale_issues.yml
+++ b/.github/workflows/autoclose_stale_issues.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '00 05 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
+          days-before-stale: 20
+          days-before-close: 10
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
Automatically stale issues after 20 days of inactivity and close them 10 days later.
