### PR TITLE
fix the issue of not returning elements with successful proofType comparisons

### DIFF
--- a/lib/iden3comm/domain/use_cases/get_iden3comm_claims_use_case.dart
+++ b/lib/iden3comm/domain/use_cases/get_iden3comm_claims_use_case.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:polygonid_flutter_sdk/common/domain/entities/filter_entity.dart';
 import 'package:polygonid_flutter_sdk/common/domain/use_case.dart';
 import 'package:polygonid_flutter_sdk/common/infrastructure/stacktrace_stream_manager.dart';
@@ -103,7 +104,7 @@ class GetIden3commClaimsUseCase
           continue;
         }
 
-        bool hasValidProofType = claimsFiltered.any((element) {
+        var validClaim = claimsFiltered.firstWhereOrNull((element) {
           List<Map<String, dynamic>> proofs = element.info["proof"];
           List<String> proofTypes =
               proofs.map((e) => e["type"] as String).toList();
@@ -147,13 +148,13 @@ class GetIden3commClaimsUseCase
           return false;
         });
 
-        if (!hasValidProofType) {
+        if (validClaim == null) {
           _stacktraceManager.addTrace(
               "[GetIden3commClaimsUseCase] claims has no valid proof type");
           continue;
         }
 
-        claims.add(claimsFiltered.first);
+        claims.add(validClaim);
       }
     }
 


### PR DESCRIPTION
fix the issue of not returning elements with successful proofType comparisons for each element in claimsFiltered, but instead returning claimsFiltered.first.

Closes #362 