### PR TITLE
Fix the issue where parsing a BigInt larger than an i32 results in verification failure

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -555,11 +555,16 @@ pub /*extern*/ fn verify_poseidon_internal(private_key: *const c_char, compresse
         Err(_) => "there",
         Ok(string) => string,
     };
+    /*
     let message_bigint = match message_str.parse::<i32>() {
         Ok(n) => BigInt::from(n),
         Err(e) => BigInt::zero(),
     };
-
+    */
+    let message_bigint = match BigInt::from_str(message_str) {
+        Ok(n) => n,
+        Err(e) => BigInt::zero(),
+    };
     if verify(pk.public(), sig.clone(), message_bigint.clone()) {
         CString::new("1".to_owned()).unwrap().into_raw()
     } else {


### PR DESCRIPTION
The handling of BigInt in verify_poseidon() should be consistent with sign_poseidon()

Verification of the signature always fails when the message(bigint) is a large integer greater than 32 bits.

The modified code can now verify the signature(returned by sign_poseidon()) correctly.