### PR TITLE
Refresh credential use-case not deleting old claim (== -> !=)

### DIFF
--- a/lib/credential/domain/use_cases/refresh_credential_use_case.dart
+++ b/lib/credential/domain/use_cases/refresh_credential_use_case.dart
@@ -88,7 +88,7 @@ class RefreshCredentialUseCase
       profileDid: param.credential.did,
     );
 
-    if (claimEntity.id == param.credential.id) {
+    if (claimEntity.id != param.credential.id) {
       await _removeClaimsUseCase.execute(
         param: RemoveClaimsParam(
           claimIds: [param.credential.id],


### PR DESCRIPTION
Hi,

The documentation of the [credential refresh service SDK](https://docs.privado.id/docs/wallet/wallet-sdk/polygonid-sdk/credential/refresh-credential/) states:

6. Removes the old claim if the refresh was successful and the id of the new claim is **different** from the old one

but in the code of polygonid-flutter-sdk/lib/credential/domain/use_cases/refresh_credential_use_case.dart:91

`...
 if (claimEntity.id == param.credential.id) {
      await _removeClaimsUseCase.execute(
...`

"remove" is called if the ids are **equal**.

Thus, it duplicates credentials in the wallet in the case of a successful refresh.