### PR TITLE
removed refresh service workaround

### DIFF
--- a/lib/credential/domain/use_cases/refresh_credential_use_case.dart
+++ b/lib/credential/domain/use_cases/refresh_credential_use_case.dart
@@ -64,7 +64,7 @@ class RefreshCredentialUseCase
       type: "https://iden3-communication.io/credentials/1.0/refresh",
       thid: id,
       body: CredentialRefreshBodyRequest(
-        param.credential.id.replaceAll("urn:uuid:", ""),
+        param.credential.id,
         "expired",
       ),
       from: param.credential.did,


### PR DESCRIPTION
The refresh service works with the following formats:

* urn:uuid:123-123
* 123-123
* https:///..../123-123