### PR TITLE
SMT old node support

### DIFF
--- a/lib/identity/domain/entities/hash_entity.dart
+++ b/lib/identity/domain/entities/hash_entity.dart
@@ -49,8 +49,16 @@ class HashEntity extends Equatable {
     });
   }
 
-  factory HashEntity.fromJson(String json) =>
-      HashEntity.fromBigInt(BigInt.parse(json));
+  factory HashEntity.fromJson(dynamic json) {
+    if (json is String) {
+      // if json is a String we can parse it directly
+      return HashEntity.fromBigInt(BigInt.parse(json));
+    } else if (json is Map<String, dynamic> && json.containsKey('data')) {
+      return HashEntity.fromBigInt(BigInt.parse(json['data']));
+    } else {
+      throw Exception('invalid format');
+    }
+  }
 
   String toJson() => toBigInt().toString();
 

--- a/lib/identity/domain/entities/node_entity.g.dart
+++ b/lib/identity/domain/entities/node_entity.g.dart
@@ -7,10 +7,9 @@ part of 'node_entity.dart';
 // **************************************************************************
 
 NodeEntity _$NodeEntityFromJson(Map<String, dynamic> json) => NodeEntity(
-      children: (json['children'] as List<dynamic>)
-          .map((e) => HashEntity.fromJson(e as String))
-          .toList(),
-      hash: HashEntity.fromJson(json['hash'] as String),
+      children:
+          (json['children'] as List<dynamic>).map(HashEntity.fromJson).toList(),
+      hash: HashEntity.fromJson(json['hash']),
       type: $enumDecode(_$NodeTypeEnumMap, json['type']),
     );
 

--- a/lib/proof/data/dtos/mtproof_dto.g.dart
+++ b/lib/proof/data/dtos/mtproof_dto.g.dart
@@ -9,9 +9,8 @@ part of 'mtproof_dto.dart';
 MTProofEntity _$MTProofEntityFromJson(Map<String, dynamic> json) =>
     MTProofEntity(
       existence: json['existence'] as bool,
-      siblings: (json['siblings'] as List<dynamic>)
-          .map((e) => HashEntity.fromJson(e as String))
-          .toList(),
+      siblings:
+          (json['siblings'] as List<dynamic>).map(HashEntity.fromJson).toList(),
       nodeAux: json['node_aux'] == null
           ? null
           : NodeAuxEntity.fromJson(json['node_aux'] as Map<String, dynamic>),


### PR DESCRIPTION
fixed issue with SMT node created with previous SDK version that contains the hash inside a Json object {"data":"hash"} instead of be a pure String