### PR TITLE
fix(payment-request-message): accepted list and object for data field of payment request message entity

### DIFF
--- a/lib/iden3comm/domain/entities/payment/response/payment_request_crypto_v1_data.dart
+++ b/lib/iden3comm/domain/entities/payment/response/payment_request_crypto_v1_data.dart
@@ -1,38 +1,36 @@
 import 'package:polygonid_flutter_sdk/iden3comm/domain/entities/payment/response/payment_request_message_entity.dart';
 
+/// https://iden3-communication.io/credentials/0.1/payment-request/#:~:text=Iden3PaymentRequestCryptoV1%20iss
 class Iden3PaymentRequestCryptoV1Data extends PaymentRequestData {
   @override
+  final String id;
   final String type;
   final PaymentRequestDataType paymentRequestDataType =
       PaymentRequestDataType.cryptoV1;
-  final String amount;
-  final String id;
   final String chainId;
   final String address;
+  final String amount;
   final String currency;
-  final String? signature;
-  final String? expiration;
+  final String? expiration; // historical backward compatibility
 
   Iden3PaymentRequestCryptoV1Data({
-    required this.type,
-    required this.amount,
     required this.id,
+    required this.type,
     required this.chainId,
     required this.address,
+    required this.amount,
     required this.currency,
-    this.signature,
     this.expiration,
   });
 
   factory Iden3PaymentRequestCryptoV1Data.fromJson(Map<String, dynamic> json) {
     return Iden3PaymentRequestCryptoV1Data(
-      type: json['type'],
-      amount: json['amount'],
       id: json['id'],
+      type: json['type'],
       chainId: json['chainId'],
       address: json['address'],
+      amount: json['amount'],
       currency: json['currency'],
-      signature: json['signature'],
       expiration: json['expiration'],
     );
   }
@@ -40,13 +38,12 @@ class Iden3PaymentRequestCryptoV1Data extends PaymentRequestData {
   @override
   Map<String, dynamic> toJson() {
     return {
-      "type": type,
-      "amount": amount,
       "id": id,
+      "type": type,
       "chainId": chainId,
       "address": address,
+      "amount": amount,
       "currency": currency,
-      "signature": signature,
       "expiration": expiration,
     };
   }

--- a/lib/iden3comm/domain/entities/payment/response/payment_request_message_entity.dart
+++ b/lib/iden3comm/domain/entities/payment/response/payment_request_message_entity.dart
@@ -113,9 +113,13 @@ class PaymentRequest {
       credentials: (json['credentials'] as List<dynamic>)
           .map((x) => CredentialInfo.fromJson(x))
           .toList(),
-      data: (json['data'] as List<dynamic>)
-          .map((x) => PaymentRequestDataFactory.fromJson(x))
-          .toList(),
+      data: json['data'] is List
+          ? (json['data'] as List<dynamic>)
+              .map((x) => PaymentRequestDataFactory.fromJson(x))
+              .toList()
+          : json['data'] is Map<String, dynamic>
+              ? [PaymentRequestDataFactory.fromJson(json['data'])]
+              : [],
     );
   }
 
@@ -189,6 +193,7 @@ class CredentialInfo {
 
 abstract class PaymentRequestData {
   String get type;
+
   PaymentRequestDataType get paymentRequestDataType;
 
   Map<String, dynamic> toJson();


### PR DESCRIPTION
due to backward compatibility, list and object are supported types for data field of the payment request message entity, especially for the old data type Iden3PaymentRequestCryptoV1