### PR TITLE
chore(deps): Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/polygonid_flutter_sdk.yml
+++ b/.github/workflows/polygonid_flutter_sdk.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
Updates the GitHub Actions checkout action from v3 to v4 to use the latest stable version.

Changes:
- Updates `actions/checkout@v3` to `actions/checkout@v4` in the GitHub Actions workflow
- This update brings performance improvements and better security features from the latest checkout action

This is a maintenance update that keeps our CI/CD dependencies up to date.