### PR TITLE
Fix Typo: Correct "occured" to "occurred" in Test Descriptions

### DIFF
--- a/test/iden3comm/domain/use_cases/authenticate_use_case_test.dart
+++ b/test/iden3comm/domain/use_cases/authenticate_use_case_test.dart
@@ -182,7 +182,7 @@ void main() {
       );
 
       test(
-        'Given a param, when I call execute and an error occured, then I expect an exception to be thrown',
+        'Given a param, when I call execute and an error occurred, then I expect an exception to be thrown',
         () async {
           // Given
           when(iden3commRepository.getAuthResponse(

--- a/test/identity/data/data_sources/wallet_data_source_test.dart
+++ b/test/identity/data/data_sources/wallet_data_source_test.dart
@@ -51,7 +51,7 @@ void main() {
     });
 
     test(
-        "Given a private key, when I call createWallet and an error occured, then I expect an exception to be thrown",
+        "Given a private key, when I call createWallet and an error occurred, then I expect an exception to be thrown",
         () async {
       // Given
       when(walletLibWrapper.createWallet(secret: anyNamed('secret')))
@@ -101,7 +101,7 @@ void main() {
     });
 
     test(
-        "Given a private key and a message, when I call signMessage and an error occured, then I expect an exception to be thrown",
+        "Given a private key and a message, when I call signMessage and an error occurred, then I expect an exception to be thrown",
         () async {
       // Given
       when(walletLibWrapper.signMessage(


### PR DESCRIPTION


**Description:**  
This pull request fixes a recurring typo in test descriptions, changing "occured" to the correct spelling "occurred" across multiple test files. No functional code was changed—only the test case descriptions were updated for clarity and correctness. This improves the readability and professionalism of the test documentation.
