### PR TITLE
Fix: Add custom method support in `fetchAndSaveClaims`

### DIFF
--- a/example/lib/src/presentation/ui/claims/claims_bloc.dart
+++ b/example/lib/src/presentation/ui/claims/claims_bloc.dart
@@ -58,7 +58,9 @@ class ClaimsBloc extends Bloc<ClaimsEvent, ClaimsState> {
     String didIdentifier = await _polygonIdSdk.identity.getDidIdentifier(
         privateKey: privateKey,
         blockchain: chainConfig.blockchain,
-        network: chainConfig.network);
+        network: chainConfig.network,
+        method: chainConfig.method,
+    );
 
     emit(const ClaimsState.loading());
 


### PR DESCRIPTION
`fetchAndSaveClaims` was missing support for `chainConfig.method`, unlike `_getClaims` and `_removeClaim`. This PR fixes that to ensure custom methods work as expected.
