### PR TITLE
Made authenticate accept predefined credentials.

### DIFF
--- a/lib/iden3comm/authenticate.dart
+++ b/lib/iden3comm/authenticate.dart
@@ -93,6 +93,7 @@ class Authenticate {
     String? challenge,
     final Map<String, dynamic>? transactionData,
     String? authClaimNonce,
+    List<RequestAndCredentials>? requestsAndCreds,
   }) async {
     final nonce = authClaimNonce ?? DEFAULT_AUTH_CLAIM_NONCE;
     try {
@@ -148,17 +149,24 @@ class Authenticate {
         ),
       );
 
-      // Get the credentials and proof requests by scope
-      final getCredentialsUseCase =
-          await getItSdk.getAsync<GetMessageRequestsAndCredsUseCase>();
-      final requestsAndCreds = await getCredentialsUseCase.execute(
-        param: GetMessageRequestsAndCredsParam(
-          message: message,
-          genesisDid: genesisDid,
-          profileNonce: profileNonce,
-          encryptionKey: privateKey,
-        ),
-      );
+      List<RequestAndCredentials> requestsAndCredsLocal;
+      if (requestsAndCreds == null) {
+        // Get the credentials and proof requests by scope
+        final getCredentialsUseCase =
+            await getItSdk.getAsync<GetMessageRequestsAndCredsUseCase>();
+        final requestsAndCredentials = await getCredentialsUseCase.execute(
+          param: GetMessageRequestsAndCredsParam(
+            message: message,
+            genesisDid: genesisDid,
+            profileNonce: profileNonce,
+            encryptionKey: privateKey,
+          ),
+        );
+
+        requestsAndCredsLocal = requestsAndCredentials;
+      } else {
+        requestsAndCredsLocal = requestsAndCreds;
+      }
 
       // this authClaimCompanionObject is the one that is being used to get the
       // authClaim, incProof, nonRevProof, treeState, authClaimNode, gistProofEntity
@@ -174,10 +182,10 @@ class Authenticate {
 
       // if there are proof requests and claims and they are the same length
       // then create the proof for every proof request
-      if (requestsAndCreds.isNotEmpty) {
+      if (requestsAndCredsLocal.isNotEmpty) {
         // it is assigning the proofs to the variable directly from the function call
         await createProofForEveryProofRequest(
-          requestsAndCreds: requestsAndCreds,
+          requestsAndCreds: requestsAndCredsLocal,
           identityEntity: identityEntity,
           groupIdLinkNonceMap: groupIdLinkNonceMap,
           genesisDid: genesisDid,

--- a/lib/sdk/iden3comm.dart
+++ b/lib/sdk/iden3comm.dart
@@ -610,6 +610,7 @@ class Iden3comm implements PolygonIdSdkIden3comm {
     required IdentityEntity identityEntity,
     required Iden3Message message,
     required EnvEntity env,
+    List<RequestAndCredentials>? requestsAndCreds,
     String? pushToken,
     String? challenge,
   }) async {
@@ -622,6 +623,7 @@ class Iden3comm implements PolygonIdSdkIden3comm {
         message: message,
         env: env,
         pushToken: pushToken,
+        requestsAndCreds: requestsAndCreds,
       );
     } on PolygonIdSDKException catch (_) {
       rethrow;


### PR DESCRIPTION
This allows us to pass optional credentials or not and select credentials for each proof request based on UI choices.